### PR TITLE
#164797973 run codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ cache:
 script:
   - npm test
   - npm run build
-after_success:
+after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 cache:
   directories:
   - node_modules
-  before_script:
+before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - CC_TEST_REPORTER_ID=76d3b07a7c25a9c634755bd41d90f02b100b3b42918bd53784da367f8910fcff
+  - CC_TEST_REPORTER_ID=76d3b07a7c25a9c634755bd41d90f02b100b3b42918bd53784da367f8910fcff
 language: node_js
 node_js:
   - "stable"


### PR DESCRIPTION
#### Description
Currently, codeclimate test-coverage does not detect test reports from Travis, and help to see lines covered and those not covered. This PR adds the ability for codeclimate test-coverage, after detecting to display the result on its badge on 'develop' run and we can measure the quality of the application.
#### Type of change

- [x] fix test coverage on travis.yml file

#### How Has This Been Tested?

- [x] Unit testing

#### Checklist:
- [x] fix test coverage on travis.yml file
#### PT-ID

[164797973](https://www.pivotaltracker.com/n/projects/2318856)

#### Screenshots
<img width="1310" alt="Screen Shot 2019-04-30 at 1 52 08 PM" src="https://user-images.githubusercontent.com/37017788/56963117-1c6d6d80-6b50-11e9-8a6e-3740b7f1a9e6.png">
<img width="981" alt="Screen Shot 2019-04-30 at 1 52 30 PM" src="https://user-images.githubusercontent.com/37017788/56963122-2000f480-6b50-11e9-8597-95e02ff70100.png">

#### Questions:
N/A