### PR TITLE
#165820603 Center Align Articles

### DIFF
--- a/src/components/presentations/UserArticles/author-articles.scss
+++ b/src/components/presentations/UserArticles/author-articles.scss
@@ -3,7 +3,7 @@ h3, p {
     font-family: $font-stack;
 }
 .profile-article-list {
-    text-align: left;
+    text-align: center;
     width: 47%;
     margin: 10px;
     padding: 10px 20px;


### PR DESCRIPTION
#### Description
Currently, the text alignment on user article on the profile page is `left`. This `PR` change the alignment to `center`. 

#### Type of change

- [x] None breaking

#### How Has This Been Tested?

- [x] Unit testing

#### Checklist:
- [x] Articles should be center aligned

#### PT-ID

[165820603](https://www.pivotaltracker.com/n/projects/2318856/stories/165820603)

#### Screenshots
<img width="1326" alt="Screenshot 2019-05-13 at 1 22 15 PM" src="https://user-images.githubusercontent.com/17157020/57621346-1e3d2500-7583-11e9-837c-8589098a5e6d.png">

#### Questions:
N/A